### PR TITLE
Add support for prometheus metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM bitwalker/alpine-elixir-phoenix:latest
+
+WORKDIR /app
+
+COPY mix.exs .
+COPY mix.lock .
+
+CMD mix prom_ex.gen.config --datasource prometheus:9090 && mix setup && mix phx.server

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -22,7 +22,7 @@ import Config
 config :shopping_cart, ShoppingCart.Repo,
   username: "postgres",
   password: "postgres",
-  hostname: "localhost",
+  hostname: "db",
   database: "shopping_cart_dev",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,16 @@ services:
       - "--config.file=/etc/prometheus/prometheus.yml"
     ports:
       - "9090:9090"
+  web:
+    build: .
+    depends_on:
+      - db
+    environment:
+      MIX_ENV: dev
+    ports:
+      - '4000:4000'
+    volumes:
+      - .:/app
 
 networks: 
   broker-kafka:

--- a/lib/shopping_cart/application.ex
+++ b/lib/shopping_cart/application.ex
@@ -21,9 +21,11 @@ defmodule ShoppingCart.Application do
       # Start Finch
       {Finch, name: ShoppingCart.Finch},
       # Start the Endpoint (http/https)
-      ShoppingCartWeb.Endpoint
+      ShoppingCartWeb.Endpoint,
+      ShoppingCart.PromEx
       # Start a worker by calling: ShoppingCart.Worker.start_link(arg)
       # {ShoppingCart.Worker, arg}
+
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -31,7 +33,6 @@ defmodule ShoppingCart.Application do
     opts = [strategy: :one_for_one, name: ShoppingCart.Supervisor]
     Supervisor.start_link(children, opts)
   end
-
   # Tell Phoenix to update the endpoint configuration
   # whenever the application is updated.
   @impl true

--- a/lib/shopping_cart/prom_ex.ex
+++ b/lib/shopping_cart/prom_ex.ex
@@ -1,0 +1,102 @@
+defmodule ShoppingCart.PromEx do
+  @moduledoc """
+  Be sure to add the following to finish setting up PromEx:
+
+  1. Update your configuration (config.exs, dev.exs, prod.exs, releases.exs, etc) to
+     configure the necessary bit of PromEx. Be sure to check out `PromEx.Config` for
+     more details regarding configuring PromEx:
+     ```
+     config :shopping_cart, ShoppingCart.PromEx,
+       disabled: false,
+       manual_metrics_start_delay: :no_delay,
+       drop_metrics_groups: [],
+       grafana: :disabled,
+       metrics_server: :disabled
+     ```
+
+  2. Add this module to your application supervision tree. It should be one of the first
+     things that is started so that no Telemetry events are missed. For example, if PromEx
+     is started after your Repo module, you will miss Ecto's init events and the dashboards
+     will be missing some data points:
+     ```
+     def start(_type, _args) do
+       children = [
+         ShoppingCart.PromEx,
+
+         ...
+       ]
+
+       ...
+     end
+     ```
+
+  3. Update your `endpoint.ex` file to expose your metrics (or configure a standalone
+     server using the `:metrics_server` config options). Be sure to put this plug before
+     your `Plug.Telemetry` entry so that you can avoid having calls to your `/metrics`
+     endpoint create their own metrics and logs which can pollute your logs/metrics given
+     that Prometheus will scrape at a regular interval and that can get noisy:
+     ```
+     defmodule ShoppingCartWeb.Endpoint do
+       use Phoenix.Endpoint, otp_app: :shopping_cart
+
+       ...
+
+       plug PromEx.Plug, prom_ex_module: ShoppingCart.PromEx
+
+       ...
+     end
+     ```
+
+  4. Update the list of plugins in the `plugins/0` function return list to reflect your
+     application's dependencies. Also update the list of dashboards that are to be uploaded
+     to Grafana in the `dashboards/0` function.
+  """
+
+  use PromEx, otp_app: :shopping_cart
+
+  alias PromEx.Plugins
+
+  @impl true
+  def plugins do
+    [
+      # PromEx built in plugins
+      Plugins.Application,
+      Plugins.Beam
+      # {Plugins.Phoenix, router: ShoppingCartWeb.Router, endpoint: ShoppingCartWeb.Endpoint},
+      # Plugins.Ecto,
+      # Plugins.Oban,
+      # Plugins.PhoenixLiveView,
+      # Plugins.Absinthe,
+      # Plugins.Broadway,
+
+      # Add your own PromEx metrics plugins
+      # ShoppingCart.Users.PromExPlugin
+    ]
+  end
+
+  @impl true
+  def dashboard_assigns do
+    [
+      datasource_id: "prometheus:9090",
+      default_selected_interval: "30s"
+    ]
+  end
+
+  @impl true
+  def dashboards do
+    [
+      # PromEx built in Grafana dashboards
+      {:prom_ex, "application.json"},
+      {:prom_ex, "beam.json"}
+      # {:prom_ex, "phoenix.json"},
+      # {:prom_ex, "ecto.json"},
+      # {:prom_ex, "oban.json"},
+      # {:prom_ex, "phoenix_live_view.json"},
+      # {:prom_ex, "absinthe.json"},
+      # {:prom_ex, "broadway.json"},
+
+      # Add your dashboard definitions here with the format: {:otp_app, "path_in_priv"}
+      # {:shopping_cart, "/grafana_dashboards/user_metrics.json"}
+    ]
+  end
+end

--- a/lib/shopping_cart_web/endpoint.ex
+++ b/lib/shopping_cart_web/endpoint.ex
@@ -34,6 +34,8 @@ defmodule ShoppingCartWeb.Endpoint do
     param_key: "request_logger",
     cookie_key: "request_logger"
 
+
+  plug PromEx.Plug, prom_ex_module: ShoppingCart.PromEx
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,8 @@ defmodule ShoppingCart.MixProject do
       # Money
       {:money, "~> 1.12.3"},
       # Kafka
-      {:kaffe, "~> 1.9"}
+      {:kaffe, "~> 1.9"},
+      {:prom_ex, "~> 1.9.0"},
     ]
   end
 

--- a/prometheus/alert.yml
+++ b/prometheus/alert.yml
@@ -1,0 +1,6 @@
+groups:
+  - name: DemoAlerts
+    rules:
+      - alert: InstanceDown 
+        expr: up{job="services"} < 1 
+        for: 5m 

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 30s
+  scrape_timeout: 10s
+
+rule_files:
+  - alert.yml
+
+scrape_configs:
+  - job_name: services
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - 'prometheus:9090'
+          - 'web:4000'


### PR DESCRIPTION
- Add the application to the docker compose file by create a Dockerfile for the project.
- Add support for prometheus metrics using the library prom_ex.